### PR TITLE
Remove obsolete function `fit_transform()`

### DIFF
--- a/BigARTM_example_EN.ipynb
+++ b/BigARTM_example_EN.ipynb
@@ -866,7 +866,7 @@
     }
    ],
    "source": [
-    "theta_matrix = model_artm.fit_transform()\n",
+    "theta_matrix = model_artm.get_theta()\n",
     "print theta_matrix"
    ]
   },

--- a/BigARTM_example_RU.ipynb
+++ b/BigARTM_example_RU.ipynb
@@ -865,7 +865,7 @@
     }
    ],
    "source": [
-    "theta_matrix = model_artm.fit_transform()\n",
+    "theta_matrix = model_artm.get_theta()\n",
     "print theta_matrix"
    ]
   },


### PR DESCRIPTION
According to the documentation, `fit_transform()` is an obsolete way of theta retrieval and `get_theta()` should be used instead.
